### PR TITLE
Fix exception thrown if some sun phases cannot be calculated

### DIFF
--- a/SunCalcNet.Tests/SunCalcTests.cs
+++ b/SunCalcNet.Tests/SunCalcTests.cs
@@ -94,8 +94,7 @@ namespace SunCalcNet.Tests
             var sunPhases = SunCalc.GetSunPhases(date, lat, lng).ToList();
 
             //Assert
-            Assert.NotNull(sunPhases[0]);
-            Assert.NotNull(sunPhases[1]);
+            Assert.Equal(2, sunPhases.Count);
         }
 
         [Fact]

--- a/SunCalcNet.Tests/SunCalcTests.cs
+++ b/SunCalcNet.Tests/SunCalcTests.cs
@@ -83,6 +83,22 @@ namespace SunCalcNet.Tests
         }
 
         [Fact]
+        public void Get_Sun_Phases_Works_At_North_Pole()
+        {
+            //Arrange
+            var date = new DateTime(2013, 3, 5, 0, 0, 0, DateTimeKind.Utc);
+            var lat = 90;
+            var lng = 135;
+
+            //Act
+            var sunPhases = SunCalc.GetSunPhases(date, lat, lng).ToList();
+
+            //Assert
+            Assert.NotNull(sunPhases[0]);
+            Assert.NotNull(sunPhases[1]);
+        }
+
+        [Fact]
         public void Get_Moon_Illumination_Returns_Fraction_And_Angle_Of_Moons_Illuminated_Limb_And_Phase()
         {
             //Arrange

--- a/SunCalcNet/Model/SunPhase.cs
+++ b/SunCalcNet/Model/SunPhase.cs
@@ -3,7 +3,7 @@
 namespace SunCalcNet.Model
 {
     [Serializable]
-    public struct SunPhase : IEquatable<SunPhase>
+    public class SunPhase : IEquatable<SunPhase>
     {
         /// <summary>
         /// Sun phase name.

--- a/SunCalcNet/Model/SunPhase.cs
+++ b/SunCalcNet/Model/SunPhase.cs
@@ -3,7 +3,7 @@
 namespace SunCalcNet.Model
 {
     [Serializable]
-    public class SunPhase : IEquatable<SunPhase>
+    public struct SunPhase : IEquatable<SunPhase>
     {
         /// <summary>
         /// Sun phase name.

--- a/SunCalcNet/SunCalc.cs
+++ b/SunCalcNet/SunCalc.cs
@@ -92,17 +92,14 @@ namespace SunCalcNet
             {
                 var jset = SunTime.GetSetJ(sunPhase.Angle * Constants.Rad, lw, phi, dec, n, m, l);
 
-                if (!double.IsNaN(jset))
+                if (double.IsNaN(jset) || double.IsInfinity(jset))
                 {
-                    var jrise = jnoon - (jset - jnoon);
-                    sunPhaseCol.Add(new SunPhase(sunPhase.RiseName, jrise.FromJulian()));
-                    sunPhaseCol.Add(new SunPhase(sunPhase.SetName, jset.FromJulian()));
+                    continue;
                 }
-                else
-                {
-                    sunPhaseCol.Add(null);
-                    sunPhaseCol.Add(null);
-                }
+
+                var jrise = jnoon - (jset - jnoon);
+                sunPhaseCol.Add(new SunPhase(sunPhase.RiseName, jrise.FromJulian()));
+                sunPhaseCol.Add(new SunPhase(sunPhase.SetName, jset.FromJulian()));
             }
 
             return sunPhaseCol;

--- a/SunCalcNet/SunCalc.cs
+++ b/SunCalcNet/SunCalc.cs
@@ -91,10 +91,18 @@ namespace SunCalcNet
             foreach (var sunPhase in SunPhaseAngle.List)
             {
                 var jset = SunTime.GetSetJ(sunPhase.Angle * Constants.Rad, lw, phi, dec, n, m, l);
-                var jrise = jnoon - (jset - jnoon);
 
-                sunPhaseCol.Add(new SunPhase(sunPhase.RiseName, jrise.FromJulian()));
-                sunPhaseCol.Add(new SunPhase(sunPhase.SetName, jset.FromJulian()));
+                if (!double.IsNaN(jset))
+                {
+                    var jrise = jnoon - (jset - jnoon);
+                    sunPhaseCol.Add(new SunPhase(sunPhase.RiseName, jrise.FromJulian()));
+                    sunPhaseCol.Add(new SunPhase(sunPhase.SetName, jset.FromJulian()));
+                }
+                else
+                {
+                    sunPhaseCol.Add(null);
+                    sunPhaseCol.Add(null);
+                }
             }
 
             return sunPhaseCol;


### PR DESCRIPTION
This fixes a bug for locations in Scandinavian countries near the North Pole where there is polar day/night (the sun stays up or down for weeks at a time).

Previously if the `jset` variable evaluated to *NaN*, the `DateTime.AddMilliseconds` call in `FromJulian` would throw an `ArgumentOutOfRangeException`. I believe the expected behavior is to return *null* sun phases in this case, which is what [suncalc.js](https://github.com/mourner/suncalc/issues/127) does.

In order to allow a `SunPhase` list to contain *null* values, I had to change `SunPhase` from a `struct` to a `class` to make it nullable. The added test failed previously but now proves that the function does not throw with the coordinates of the North Pole, and at least the first two phases are always calculated.