### PR TITLE
Cache sun phase angle definitions

### DIFF
--- a/SunCalcNet/Model/SunPhaseAngle.cs
+++ b/SunCalcNet/Model/SunPhaseAngle.cs
@@ -6,6 +6,18 @@ namespace SunCalcNet.Model
     [Serializable]
     public class SunPhaseAngle
     {
+        private static readonly SunPhaseAngle[] Values =
+        {
+            new(-0.833, SunPhaseName.Sunrise, SunPhaseName.Sunset),
+            new(-0.3, SunPhaseName.SunriseEnd, SunPhaseName.SunsetStart),
+            new(-6, SunPhaseName.Dawn, SunPhaseName.Dusk),
+            new(-12, SunPhaseName.NauticalDawn, SunPhaseName.NauticalDusk),
+            new(-18, SunPhaseName.NightEnd, SunPhaseName.Night),
+            new(6, SunPhaseName.GoldenHourEnd, SunPhaseName.GoldenHour)
+        };
+
+        private static readonly IEnumerable<SunPhaseAngle> ReadOnlyValues = Array.AsReadOnly(Values);
+
         public double Angle { get; }
 
         public SunPhaseName RiseName { get; }
@@ -19,14 +31,13 @@ namespace SunCalcNet.Model
             SetName = setName;
         }
 
-        public static IEnumerable<SunPhaseAngle> List => new List<SunPhaseAngle>
+        internal static int Count => Values.Length;
+
+        internal static SunPhaseAngle GetAt(int index)
         {
-            new(-0.833, SunPhaseName.Sunrise, SunPhaseName.Sunset),
-            new(-0.3, SunPhaseName.SunriseEnd, SunPhaseName.SunsetStart),
-            new(-6, SunPhaseName.Dawn, SunPhaseName.Dusk),
-            new(-12, SunPhaseName.NauticalDawn, SunPhaseName.NauticalDusk),
-            new(-18, SunPhaseName.NightEnd, SunPhaseName.Night),
-            new(6, SunPhaseName.GoldenHourEnd, SunPhaseName.GoldenHour)
-        };
+            return Values[index];
+        }
+
+        public static IEnumerable<SunPhaseAngle> List => ReadOnlyValues;
     }
 }

--- a/SunCalcNet/Model/SunPhaseAngle.cs
+++ b/SunCalcNet/Model/SunPhaseAngle.cs
@@ -16,7 +16,7 @@ namespace SunCalcNet.Model
             new(6, SunPhaseName.GoldenHourEnd, SunPhaseName.GoldenHour)
         };
 
-        private static readonly IEnumerable<SunPhaseAngle> ReadOnlyValues = Array.AsReadOnly(Values);
+        private static readonly IReadOnlyCollection<SunPhaseAngle> ReadOnlyValues = Array.AsReadOnly(Values);
 
         public double Angle { get; }
 
@@ -38,6 +38,6 @@ namespace SunCalcNet.Model
             return Values[index];
         }
 
-        public static IEnumerable<SunPhaseAngle> List => ReadOnlyValues;
+        public static IReadOnlyCollection<SunPhaseAngle> List => ReadOnlyValues;
     }
 }

--- a/SunCalcNet/SunCalc.cs
+++ b/SunCalcNet/SunCalc.cs
@@ -67,7 +67,7 @@ namespace SunCalcNet
 
             for (var i = 0; i < SunPhaseAngle.Count; i++)
             {
-                 var sunPhase = SunPhaseAngle.GetAt(i);
+                var sunPhase = SunPhaseAngle.GetAt(i);
                 var h0 = (sunPhase.Angle + dh) * Constants.Rad;
                 var jset = SunTime.GetSetJ(h0, lw, phi, dec, n, m, l);
 

--- a/SunCalcNet/SunCalc.cs
+++ b/SunCalcNet/SunCalc.cs
@@ -59,14 +59,15 @@ namespace SunCalcNet
             var solarNoon = jnoon.FromJulian();
             var nadir = (jnoon - 0.5).FromJulian();
 
-            var sunPhaseCol = new List<SunPhase>
+            var sunPhaseCol = new List<SunPhase>(2 + SunPhaseAngle.Count * 2)
             {
                 new(SunPhaseName.SolarNoon, solarNoon),
                 new(SunPhaseName.Nadir, nadir)
             };
 
-            foreach (var sunPhase in SunPhaseAngle.List)
+            for (var i = 0; i < SunPhaseAngle.Count; i++)
             {
+                 var sunPhase = SunPhaseAngle.GetAt(i);
                 var h0 = (sunPhase.Angle + dh) * Constants.Rad;
                 var jset = SunTime.GetSetJ(h0, lw, phi, dec, n, m, l);
 


### PR DESCRIPTION
## Summary
- Implements the selected highest-impact / lowest-effort optimization from the performance review: cache the fixed sun phase angle definitions instead of allocating a new list and six `SunPhaseAngle` objects on every `GetSunPhases` call.
- Pre-sizes the `SunPhase` result list and iterates the cached table by index internally to avoid extra list growth/enumerator overhead.
- Preserves the public `SunPhaseAngle.List` API via a read-only cached wrapper.

## Scope clarification
This PR intentionally implements only the selected optimization. The other performance ideas below were identified during review and are listed as follow-up candidates, not as changes included in this PR.

## Performance improvements identified
| # | Improvement | Status |
|---|-------------|--------|
| 1 | Cache immutable `SunPhaseAngle` definitions and stop rebuilding them per `GetSunPhases` call. | Implemented in this PR |
| 2 | Pre-size the `GetSunPhases` result list to its maximum expected count. | Implemented in this PR |
| 3 | Cache `sin`/`cos` of `Constants.EarthObliquity` in `Position` instead of recalculating constants in right ascension and declination. | Follow-up candidate |
| 4 | Cache `sin`/`cos` of latitude and declination while computing sun phase hour angles. | Follow-up candidate |
| 5 | Add combined position helpers that compute azimuth and altitude together so shared trig values are not recalculated. | Follow-up candidate |
| 6 | In `GetMoonPosition`, reuse `sin`/`cos` values across altitude, azimuth, and parallactic-angle calculations. | Follow-up candidate |
| 7 | In `GetMoonPhase`, compute sample times from a base Julian day plus hour offsets instead of repeatedly creating `DateTime` values and converting them back to days. | Follow-up candidate |
| 8 | Cache the Unix epoch `DateTime` used by `FromJulian` instead of constructing it on every conversion. | Follow-up candidate |
| 9 | Replace repeated `ToUniversalTime().ToOADate()` date conversion with direct tick-based Julian day arithmetic. | Follow-up candidate |
| 10 | In `GetMoonIllumination`, cache repeated `sin`/`cos` values for declinations and right-ascension delta. | Follow-up candidate |

Selected this PR because it removes deterministic allocations from a public hot path with very small, low-risk code changes.

## Validation
- `dotnet restore .\\SunCalcNet.sln --verbosity minimal`
- `dotnet test .\\SunCalcNet.sln --no-restore --verbosity minimal`