### PR TITLE
Use explicit days-since-J2000 naming

### DIFF
--- a/SunCalcNet/Internal/Moon.cs
+++ b/SunCalcNet/Internal/Moon.cs
@@ -20,13 +20,13 @@ namespace SunCalcNet.Internal
         /// <summary>
         /// Get Moon geocentric coordinates based on days since J2000.0 epoch
         /// </summary>
-        /// <param name="days">Days since J2000.0 (January 1, 2000 12:00 UTC)</param>
+        /// <param name="daysSinceJ2000">Days since J2000.0 (January 1, 2000 12:00 UTC)</param>
         /// <returns>Geocentric coordinates of the Moon</returns>
-        internal static GeocentricCoords GetGeocentricCoords(double days)
+        internal static GeocentricCoords GetGeocentricCoords(double daysSinceJ2000)
         {
-            var eclipticLongitude = Constants.Rad * (LongitudeBase + LongitudeRate * days);
-            var meanAnomaly = Constants.Rad * (MeanAnomalyBase + MeanAnomalyRate * days);
-            var meanDistance = Constants.Rad * (MeanDistanceBase + MeanDistanceRate * days);
+            var eclipticLongitude = Constants.Rad * (LongitudeBase + LongitudeRate * daysSinceJ2000);
+            var meanAnomaly = Constants.Rad * (MeanAnomalyBase + MeanAnomalyRate * daysSinceJ2000);
+            var meanDistance = Constants.Rad * (MeanDistanceBase + MeanDistanceRate * daysSinceJ2000);
 
 
             var longitude = eclipticLongitude + Constants.Rad * LongitudePerturbation * Math.Sin(meanAnomaly);

--- a/SunCalcNet/Internal/Position.cs
+++ b/SunCalcNet/Internal/Position.cs
@@ -72,12 +72,12 @@ namespace SunCalcNet.Internal
         /// <summary>
         /// Calculates the local sidereal time.
         /// </summary>
-        /// <param name="julianDay">The julian day.</param>
+        /// <param name="daysSinceJ2000">Days since J2000.0 (January 1, 2000 12:00 UTC).</param>
         /// <param name="longitudeWest">The longitude west in radians.</param>
         /// <returns>The local sidereal time in radians.</returns>
-        internal static double GetSiderealTime(double julianDay, double longitudeWest)
+        internal static double GetSiderealTime(double daysSinceJ2000, double longitudeWest)
         {
-            return Constants.Rad * (SiderealBase + SiderealCoefficient * julianDay) - longitudeWest;
+            return Constants.Rad * (SiderealBase + SiderealCoefficient * daysSinceJ2000) - longitudeWest;
         }
 
         /// <summary>

--- a/SunCalcNet/Internal/Sun.cs
+++ b/SunCalcNet/Internal/Sun.cs
@@ -8,11 +8,11 @@ namespace SunCalcNet.Internal
         /// <summary>
         /// The position that the planet would have relative to its perihelion if the orbit of the planet were a circle is called the mean anomaly.
         /// </summary>
-        /// <param name="days"> Julian Day Number</param>
+        /// <param name="daysSinceJ2000">Days since J2000.0 (January 1, 2000 12:00 UTC).</param>
         /// <returns></returns>
-        internal static double GetMeanAnomaly(double days)
+        internal static double GetMeanAnomaly(double daysSinceJ2000)
         {
-            return Constants.Rad * (357.5291 + 0.98560028 * days);
+            return Constants.Rad * (357.5291 + 0.98560028 * daysSinceJ2000);
         }
 
         /// <summary>
@@ -29,11 +29,11 @@ namespace SunCalcNet.Internal
         /// <summary>
         /// Get Sun coordinates.
         /// </summary>
-        /// <param name="days"></param>
+        /// <param name="daysSinceJ2000">Days since J2000.0 (January 1, 2000 12:00 UTC).</param>
         /// <returns></returns>
-        internal static EquatorialCoords GetEquatorialCoords(double days)
+        internal static EquatorialCoords GetEquatorialCoords(double daysSinceJ2000)
         {
-            var meanAnomaly = GetMeanAnomaly(days);
+            var meanAnomaly = GetMeanAnomaly(daysSinceJ2000);
             var eclipticLongitude = GetEclipticLongitude(meanAnomaly);
 
             var dec = Position.GetDeclination(eclipticLongitude, 0);

--- a/SunCalcNet/Internal/SunTime.cs
+++ b/SunCalcNet/Internal/SunTime.cs
@@ -4,9 +4,9 @@ namespace SunCalcNet.Internal
 {
     internal static class SunTime
     {
-        internal static double GetJulianCycle(double d, double lw)
+        internal static double GetJulianCycle(double daysSinceJ2000, double lw)
         {
-            return Math.Round(d - Constants.J0 - lw / (2 * Math.PI));
+            return Math.Round(daysSinceJ2000 - Constants.J0 - lw / (2 * Math.PI));
         }
 
         internal static double GetApproxTransit(double ht, double lw, double n)
@@ -14,9 +14,9 @@ namespace SunCalcNet.Internal
             return Constants.J0 + (ht + lw) / (2 * Math.PI) + n;
         }
 
-        internal static double GetSolarTransitJ(double ds, double m, double l)
+        internal static double GetSolarTransitJ(double approxTransitDaysSinceJ2000, double m, double l)
         {
-            return Constants.J2000 + ds + 0.0053 * Math.Sin(m) - 0.0069 * Math.Sin(2 * l);
+            return Constants.J2000 + approxTransitDaysSinceJ2000 + 0.0053 * Math.Sin(m) - 0.0069 * Math.Sin(2 * l);
         }
 
         /// <summary>
@@ -33,8 +33,8 @@ namespace SunCalcNet.Internal
         internal static double GetSetJ(double h, double lw, double phi, double dec, double n, double m, double l)
         {
             var w = GetHourAngle(h, phi, dec);
-            var a = GetApproxTransit(w, lw, n);
-            return GetSolarTransitJ(a, m, l);
+            var approxTransitDaysSinceJ2000 = GetApproxTransit(w, lw, n);
+            return GetSolarTransitJ(approxTransitDaysSinceJ2000, m, l);
         }
         
         internal static double GetObserverAngle(double height)

--- a/SunCalcNet/MoonCalc.cs
+++ b/SunCalcNet/MoonCalc.cs
@@ -40,10 +40,10 @@ namespace SunCalcNet
         /// <returns>The moon illumination parameters for the given date.</returns>
         public static MoonIllumination GetMoonIllumination(DateTime date)
         {
-            var d = date.ToDays();
+            var daysSinceJ2000 = date.ToDaysSinceJ2000();
             const int sdist = 149598000; // distance from Earth to Sun in km
-            var sunCoords = Sun.GetEquatorialCoords(d);
-            var moonCoords = Moon.GetGeocentricCoords(d);
+            var sunCoords = Sun.GetEquatorialCoords(daysSinceJ2000);
+            var moonCoords = Moon.GetGeocentricCoords(daysSinceJ2000);
 
             var phi = Math.Acos(Math.Sin(sunCoords.Declination) * Math.Sin(moonCoords.Declination) +
                                 Math.Cos(sunCoords.Declination) * Math.Cos(moonCoords.Declination) *
@@ -77,7 +77,8 @@ namespace SunCalcNet
             var lw = Constants.Rad * -lng;
             var phi = Constants.Rad * lat;
             const double hc = 0.133 * Constants.Rad;
-            var h0 = GetMoonPositionCalculation(date, lw, phi).ApparentAltitude - hc;
+            var daysSinceJ2000 = date.ToDaysSinceJ2000();
+            var h0 = GetMoonPositionCalculation(daysSinceJ2000, lw, phi).ApparentAltitude - hc;
             double? rise = null;
             double? set = null;
             double ye = 0;
@@ -153,9 +154,13 @@ namespace SunCalcNet
 
         private static MoonPositionCalculation GetMoonPositionCalculation(DateTime date, double lw, double phi)
         {
-            var d = date.ToDays();
-            var moonCoords = Moon.GetGeocentricCoords(d);
-            var h = Position.GetSiderealTime(d, lw) - moonCoords.RightAscension;
+            return GetMoonPositionCalculation(date.ToDaysSinceJ2000(), lw, phi);
+        }
+
+        private static MoonPositionCalculation GetMoonPositionCalculation(double daysSinceJ2000, double lw, double phi)
+        {
+            var moonCoords = Moon.GetGeocentricCoords(daysSinceJ2000);
+            var h = Position.GetSiderealTime(daysSinceJ2000, lw) - moonCoords.RightAscension;
             var geometricAltitude = Position.GetAltitude(h, phi, moonCoords.Declination);
 
             return new MoonPositionCalculation(

--- a/SunCalcNet/SunCalc.cs
+++ b/SunCalcNet/SunCalc.cs
@@ -19,10 +19,10 @@ namespace SunCalcNet
         {
             var lw = Constants.Rad * -lng;
             var phi = Constants.Rad * lat;
-            var d = date.ToDays();
+            var daysSinceJ2000 = date.ToDaysSinceJ2000();
 
-            var sunCoords = Sun.GetEquatorialCoords(d);
-            var h = Position.GetSiderealTime(d, lw) - sunCoords.RightAscension;
+            var sunCoords = Sun.GetEquatorialCoords(daysSinceJ2000);
+            var h = Position.GetSiderealTime(daysSinceJ2000, lw) - sunCoords.RightAscension;
 
             var azimuth = Position.GetAzimuth(h, phi, sunCoords.Declination);
             var altitude = Position.GetAltitude(h, phi, sunCoords.Declination);
@@ -46,16 +46,16 @@ namespace SunCalcNet
 
             var dh = SunTime.GetObserverAngle(height);
             
-            var d = date.ToDays();
+            var daysSinceJ2000 = date.ToDaysSinceJ2000();
 
-            var n = SunTime.GetJulianCycle(d, lw);
-            var ds = SunTime.GetApproxTransit(0, lw, n);
+            var n = SunTime.GetJulianCycle(daysSinceJ2000, lw);
+            var approxTransitDaysSinceJ2000 = SunTime.GetApproxTransit(0, lw, n);
 
-            var m = Sun.GetMeanAnomaly(ds);
+            var m = Sun.GetMeanAnomaly(approxTransitDaysSinceJ2000);
             var l = Sun.GetEclipticLongitude(m);
             var dec = Position.GetDeclination(l, 0);
 
-            var jnoon = SunTime.GetSolarTransitJ(ds, m, l);
+            var jnoon = SunTime.GetSolarTransitJ(approxTransitDaysSinceJ2000, m, l);
             var solarNoon = jnoon.FromJulian();
             var nadir = (jnoon - 0.5).FromJulian();
 

--- a/SunCalcNet/Utils/DateTimeUtils.cs
+++ b/SunCalcNet/Utils/DateTimeUtils.cs
@@ -13,7 +13,7 @@ namespace SunCalcNet.Utils
             return new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddMilliseconds((j + 0.5 - Constants.J1970) * DayMs);
         }
 
-        public static double ToDays(this DateTime date)
+        public static double ToDaysSinceJ2000(this DateTime date)
         {
             return ToJulianDate(date) - Constants.J2000;
         }


### PR DESCRIPTION
## Summary
- Rename the internal `DateTime` helper from `ToDays` to `ToDaysSinceJ2000` so the unit and epoch are explicit.
- Use `daysSinceJ2000` for related locals and helper parameters in sun/moon calculation paths.
- Keep moon phase sampling on `date.HoursLater(...)` / `DateTime.AddHours(...)` instead of fractional-day UTC offsets.
- Preserve existing behavior for clients that pass local or unspecified `DateTime` values, including DST-transition days.

## Feedback addressed
The earlier fractional-day moon sampling optimization could diverge from the previous behavior for `DateTimeKind.Local` or `Unspecified` on DST-transition days. Since clients may pass local times, this PR now favors the simpler and behavior-safe `DateTime.AddHours(...)` sampling path.

Follow-up review feedback also pointed out that `days`, `d`, `julianDay`, `ds`, and `a` were ambiguous where they represented days since J2000. Those names are now explicit where the value really is days since the J2000 epoch, while unrelated math variables such as the quadratic discriminant `d` remain unchanged.

## Performance opportunities identified
1. Precompute observer/declination sine and cosine values in `GetSunPhases`/`SunTime.GetHourAngle`.
2. Cache `2 * Math.PI` or its reciprocal in `SunTime` transit calculations.
3. Replace repeated epoch construction in `DateTimeUtils.FromJulian`.
4. Replace `ToUniversalTime().ToOADate()` with direct UTC tick arithmetic after verifying exact rounding behavior.
5. Cache repeated trigonometric inputs in `GetMoonIllumination`.
6. Share sine/cosine calculations between moon azimuth and parallactic-angle calculations.
7. Use trigonometric recurrences in `Sun.GetEquationOfCenter`.
8. Store radian-scaled constants/rates in `Moon.GetGeocentricCoords`.
9. Consider batch/location-context APIs for repeated same-location calculations.
10. Revisit moon phase sampling only with explicit UTC-only semantics or tests covering local/DST behavior.

## Validation
- `dotnet test C:\Users\KosteBudinoski\copilot-worktrees\SunCalcNet\kostebudinoski-sturdy-carnival\SunCalcNet.sln --nologo --verbosity minimal` was run from outside the repo path because `global.json` pins SDK `10.0.301`, which is not installed in this environment. The available SDK completed all 8 tests successfully.